### PR TITLE
Add pre-commit config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-added-large-files
+    -   id: requirements-txt-fixer
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.13
+    hooks:
+    # Run the linter.
+    -   id: ruff
+        args: [ --fix ]
+    # Run the formatter.
+    -   id: ruff-format


### PR DESCRIPTION
Pre-commit uses ruff and attempts to auto-fix most of the formatting inconsistencies.